### PR TITLE
Fix failing "testfile: /tmp/testresult.json.data written" tests

### DIFF
--- a/t/23-Monitoring-Livestatus-BigData.t
+++ b/t/23-Monitoring-Livestatus-BigData.t
@@ -24,7 +24,7 @@ for my $x (1..$testresults) {
 }
 print $fh "]\n";
 close($fh);
-ok(-f $testfile, "testfile: ".$testfile.".data written");
+ok(-f $testfile.".data", "testfile: ".$testfile.".data written");
 
 my $size = -s $testfile.".data";
 ok($size, "file has $size bytes");


### PR DESCRIPTION
Hi! I was assigned your module for CPAN-PR challenge December 2016.

I have found out that you had failing tests. I was able to track it down, luckily it was just a broken test.
We were checking IF `/tmp/testresult.json` exists after writing `/tmp/testresult.json.data`. 

(`.json` file was being created after this failing test, so when I tried to `prove 23*` twice, it used to pass all tests)

This commit hopefully should fix the issue, and will make cpan-testers happy.

Please feel free to modify/comment on my changes.
Thanks!