### PR TITLE
Fix spelling errors.

### DIFF
--- a/lib/Monitoring/Livestatus.pm
+++ b/lib/Monitoring/Livestatus.pm
@@ -84,21 +84,21 @@ address
 
 verbose mode
 
-=item line_seperator
+=item line_separator
 
-ascii code of the line seperator, defaults to 10, (newline)
+ascii code of the line separator, defaults to 10, (newline)
 
-=item column_seperator
+=item column_separator
 
-ascii code of the column seperator, defaults to 0 (null byte)
+ascii code of the column separator, defaults to 0 (null byte)
 
-=item list_seperator
+=item list_separator
 
-ascii code of the list seperator, defaults to 44 (comma)
+ascii code of the list separator, defaults to 44 (comma)
 
-=item host_service_seperator
+=item host_service_separator
 
-ascii code of the host/service seperator, defaults to 124 (pipe)
+ascii code of the host/service separator, defaults to 124 (pipe)
 
 =item keepalive
 
@@ -143,10 +143,10 @@ sub new {
       'server'                      => undef,   # use tcp connections
       'peer'                        => undef,   # use for socket / server connections
       'name'                        => undef,   # human readable name
-      'line_seperator'              => 10,      # defaults to newline
-      'column_seperator'            => 0,       # defaults to null byte
-      'list_seperator'              => 44,      # defaults to comma
-      'host_service_seperator'      => 124,     # defaults to pipe
+      'line_separator'              => 10,      # defaults to newline
+      'column_separator'            => 0,       # defaults to null byte
+      'list_separator'              => 44,      # defaults to comma
+      'host_service_separator'      => 124,     # defaults to pipe
       'keepalive'                   => 0,       # enable keepalive?
       'errors_are_fatal'            => 1,       # die on errors
       'backend'                     => undef,   # should be keept undef, used internally
@@ -159,6 +159,22 @@ sub new {
       'retries_on_connection_error' => 3,       # retry x times to connect
       'retry_interval'              => 1,       # retry after x seconds
     };
+
+    my %old_key = (
+                    line_seperator         => 'line_separator',
+                    column_seperator       => 'column_separator',
+                    list_seperator         => 'list_separator',
+                    host_service_seperator => 'host_service_separator',
+                  );
+
+    # previous versions had spelling errors in the key name
+    for my $opt_key (keys %old_key) {
+        if(exists $options{$opt_key}) {
+            my $value = $options{$opt_key};
+            $options{ $old_key{$opt_key} } = $value;
+            delete $options{$opt_key};
+        }
+    }
 
     for my $opt_key (keys %options) {
         if(exists $self->{$opt_key}) {
@@ -1013,7 +1029,7 @@ useful when using multiple backends.
     deep copy/clone the result set.
 
     Only effective when using multiple backends and threads.
-    This can be safely turned off if you dont change the
+    This can be safely turned off if you don't change the
     result set.
     If you get an error like "Invalid value for shared scalar" error" this
     should be turned on.
@@ -1382,7 +1398,7 @@ sub _get_error {
         '452' => 'internal livestatus error',
         '490' => 'no query',
         '491' => 'failed to connect',
-        '492' => 'Separators not allowed in statement. Please use the seperator options in new()',
+        '492' => 'Separators not allowed in statement. Please use the separator options in new()',
         '493' => 'OuputFormat not allowed in statement. Header will be set automatically',
         '494' => 'ColumnHeaders not allowed in statement. Header will be set automatically',
         '495' => 'ResponseHeader not allowed in statement. Header will be set automatically',

--- a/t/01-Monitoring-Livestatus-basic_tests.t
+++ b/t/01-Monitoring-Livestatus-basic_tests.t
@@ -37,13 +37,13 @@ is($ml->peer_addr(), $socket_path, 'get peer_addr()');
 
 #########################
 # create object with hash args
-my $line_seperator        = 10;
-my $column_seperator      = 0;
+my $line_separator        = 10;
+my $column_separator      = 0;
 $ml = Monitoring::Livestatus->new(
                                     verbose             => 0,
                                     socket              => $socket_path,
-                                    line_seperator      => $line_seperator,
-                                    column_seperator    => $column_seperator,
+                                    line_separator      => $line_separator,
+                                    column_separator    => $column_separator,
                                 );
 isa_ok($ml, 'Monitoring::Livestatus', 'new hash args');
 is($ml->peer_name(), $socket_path, 'get peer_name()');

--- a/t/20-Monitoring-Livestatus-test_socket.t
+++ b/t/20-Monitoring-Livestatus-test_socket.t
@@ -30,8 +30,8 @@ BEGIN { use_ok('Monitoring::Livestatus') };
 #########################
 # Normal Querys
 #########################
-my $line_seperator      = 10;
-my $column_seperator    = 0;
+my $line_separator      = 10;
+my $column_separator    = 0;
 my $test_data           = [ ["alias","name","contacts"],       # table header
                             ["alias1","host1","contact1"],     # row 1
                             ["alias2","host2","contact2"],     # row 2
@@ -112,8 +112,8 @@ my $objects_to_test = {
   'unix_hash_args' => Monitoring::Livestatus->new(
                                       verbose             => 0,
                                       socket              => $socket_path,
-                                      line_seperator      => $line_seperator,
-                                      column_seperator    => $column_seperator,
+                                      line_separator      => $line_separator,
+                                      column_separator    => $column_separator,
                                     ),
 
   # create unix object with a single arg
@@ -123,8 +123,8 @@ my $objects_to_test = {
   'inet_hash_args' => Monitoring::Livestatus->new(
                                       verbose             => 0,
                                       server              => $server,
-                                      line_seperator      => $line_seperator,
-                                      column_seperator    => $column_seperator,
+                                      line_separator      => $line_separator,
+                                      column_separator    => $column_separator,
                                     ),
 
   # create inet object with a single arg
@@ -136,7 +136,7 @@ for my $key (keys %{$objects_to_test}) {
     my $ml = $objects_to_test->{$key};
     isa_ok($ml, 'Monitoring::Livestatus');
 
-    # we dont need warnings for testing
+    # we don't need warnings for testing
     $ml->warnings(0);
 
     ##################################################

--- a/t/21-Monitoring-Livestatus-INET.t
+++ b/t/21-Monitoring-Livestatus-INET.t
@@ -19,12 +19,12 @@ isa_ok($ml, 'Monitoring::Livestatus', 'Monitoring::Livestatus::INET->new()');
 
 #########################
 # create object with hash args
-my $line_seperator        = 10;
-my $column_seperator      = 0;
+my $line_separator        = 10;
+my $column_separator      = 0;
 $ml = Monitoring::Livestatus::INET->new(
                                     verbose             => 0,
                                     server              => $server,
-                                    line_seperator      => $line_seperator,
-                                    column_seperator    => $column_seperator,
+                                    line_separator      => $line_separator,
+                                    column_separator    => $column_separator,
                                 );
 isa_ok($ml, 'Monitoring::Livestatus', 'Monitoring::Livestatus::INET->new(%args)');

--- a/t/22-Monitoring-Livestatus-UNIX.t
+++ b/t/22-Monitoring-Livestatus-UNIX.t
@@ -15,12 +15,12 @@ isa_ok($ml, 'Monitoring::Livestatus', 'Monitoring::Livestatus::UNIX->new()');
 
 #########################
 # create object with hash args
-my $line_seperator        = 10;
-my $column_seperator      = 0;
+my $line_separator        = 10;
+my $column_separator      = 0;
 $ml = Monitoring::Livestatus::UNIX->new(
                                     verbose             => 0,
                                     socket              => $socket,
-                                    line_seperator      => $line_seperator,
-                                    column_seperator    => $column_seperator,
+                                    line_separator      => $line_separator,
+                                    column_separator    => $column_separator,
                                 );
 isa_ok($ml, 'Monitoring::Livestatus', 'Monitoring::Livestatus::UNIX->new(%args)');

--- a/t/30-Monitoring-Livestatus-live-test.t
+++ b/t/30-Monitoring-Livestatus-live-test.t
@@ -27,8 +27,8 @@ use_ok('Monitoring::Livestatus::INET');
 use_ok('Monitoring::Livestatus::UNIX');
 
 #########################
-my $line_seperator      = 10;
-my $column_seperator    = 0;
+my $line_separator      = 10;
+my $column_separator    = 0;
 my $objects_to_test = {
   # UNIX
   # create unix object with a single arg
@@ -38,8 +38,8 @@ my $objects_to_test = {
   '02 unix_few_args' => Monitoring::Livestatus->new(
                                       #verbose             => 1,
                                       socket              => $ENV{TEST_SOCKET},
-                                      line_seperator      => $line_seperator,
-                                      column_seperator    => $column_seperator,
+                                      line_separator      => $line_separator,
+                                      column_separator    => $column_separator,
                                     ),
 
   # create unix object with hash args
@@ -57,8 +57,8 @@ my $objects_to_test = {
   '05 inet_few_args' => Monitoring::Livestatus->new(
                                       verbose             => 0,
                                       server              => $ENV{TEST_SERVER},
-                                      line_seperator      => $line_seperator,
-                                      column_seperator    => $column_seperator,
+                                      line_separator      => $line_separator,
+                                      column_separator    => $column_separator,
                                     ),
 
 
@@ -179,7 +179,7 @@ for my $key (sort keys %{$objects_to_test}) {
     my $ml = $objects_to_test->{$key};
     isa_ok($ml, 'Monitoring::Livestatus') or BAIL_OUT("no need to continue without a proper Monitoring::Livestatus object: ".$key);
 
-    # dont die on errors
+    # don't die on errors
     $ml->errors_are_fatal(0);
     $ml->warnings(0);
 
@@ -238,7 +238,7 @@ for my $key (sort keys %{$objects_to_test}) {
 
     #########################
     # send a test command
-    # commands still dont work and breaks livestatus
+    # commands still don't work and breaks livestatus
     my $rt = $ml->do('COMMAND ['.time().'] SAVE_STATE_INFORMATION');
     is($rt, '1', $key.' test command');
 

--- a/t/32-Monitoring-Livestatus-backend-test.t
+++ b/t/32-Monitoring-Livestatus-backend-test.t
@@ -11,7 +11,7 @@ if ( ! defined $ENV{TEST_SOCKET} or !defined $ENV{TEST_SERVER} or !defined $ENV{
     my $msg = 'Author test.  Set $ENV{TEST_SOCKET} and $ENV{TEST_SERVER} and $ENV{TEST_BACKEND} to run';
     plan( skip_all => $msg );
 } else {
-    # we dont know yet how many tests we got
+    # we don't know yet how many tests we got
     plan( tests => 57070 );
 }
 
@@ -39,7 +39,7 @@ for my $key (sort keys %{$objects_to_test}) {
     my $ml = $objects_to_test->{$key};
     isa_ok($ml, 'Monitoring::Livestatus') or BAIL_OUT("no need to continue without a proper Monitoring::Livestatus object: ".$key);
 
-    # dont die on errors
+    # don't die on errors
     $ml->errors_are_fatal(0);
     $ml->warnings(0);
 

--- a/t/33-Monitoring-Livestatus-test_socket_timeout.t
+++ b/t/33-Monitoring-Livestatus-test_socket_timeout.t
@@ -53,7 +53,7 @@ for my $key (sort keys %{$objects_to_test}) {
     my $ml = $objects_to_test->{$key};
     isa_ok($ml, 'Monitoring::Livestatus');
 
-    # we dont need warnings for testing
+    # we don't need warnings for testing
     $ml->warnings(0);
 
     #########################

--- a/t/34-Monitoring-Livestatus-utf8_support.t
+++ b/t/34-Monitoring-Livestatus-utf8_support.t
@@ -44,7 +44,7 @@ for my $key (sort keys %{$objects_to_test}) {
     my $ml = $objects_to_test->{$key};
     isa_ok($ml, 'Monitoring::Livestatus');
 
-    # we dont need warnings for testing
+    # we don't need warnings for testing
     $ml->warnings(0);
 
     #########################


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the Debian package build:

 * seperator -> separator
 * dont      -> don't

The 'seperator' typo was included in option keys, so I've added code to migrate the old keys to the new ones to keep compatibility.