### PR TITLE
Increase sleep to allow netcat to start.

### DIFF
--- a/t/23-Monitoring-Livestatus-BigData.t
+++ b/t/23-Monitoring-Livestatus-BigData.t
@@ -42,7 +42,7 @@ ok($mem_start, sprintf('memory at start: %.2f MB', $mem_start/1024));
 ##########################################################
 # start netcat
 `netcat -vvv -w 3 -l -p $testport >/dev/null 2>&1 < $testfile &`;
-sleep(0.1);
+sleep(1);
 ok(1, "netcat started");
 
 ##########################################################


### PR DESCRIPTION
`t/23-Monitoring-Livestatus-BigData.t` tended to fail as part of the Debian package build due to connections being refused because netcat hadn't completed startup yet.